### PR TITLE
Corrects the documentation of the user model in the readme to say PBKDF2 instead of SHA1

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ A Redis hash named `user:<user id>` with the following fields:
 
     id -> user ID
     username -> The username
-    password -> Hashed password, SHA1(salt|password) note: | means concatenation
+    password -> Hashed password, PBKDF2(salt|password) note: | means concatenation
     ctime -> Registration time (unix time)
     karma -> User karma, earned visiting the site and posting good stuff
     about -> Some optional info about the user


### PR DESCRIPTION
Hopefully this will stop people whining in future.
