### PR TITLE
This doc change lets non-ruby guys just run "gem install <list>" and get going.

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,16 +18,13 @@ Installation
 ===
 
 Lamer news is a Ruby/Sinatra/Redis/jQuery application.
-You just need Ruby 1.8.7 with the following gems:
+You need to install Redis and Ruby 1.8.7 with the following gems:
 
 * redis
 * hiredis
 * sinatra
 * json
-* digest/sha1
-* digest/md5
 * ruby-hmac
-* openssl (not required but suggested to speedup password hashing)
 
 How to contribute
 ===


### PR DESCRIPTION
I'm a Python guy, so I wasted some time trying to figure out why digest/\* and openssl weren't being found, etc. Aside from installing redis and changing the port (why 10000 default in app_config.rb ?), got it running pretty quickly.

Nice job :)
