### PR TITLE
Nested/duplicate <form> tags and CSRF bug.

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -644,11 +644,6 @@ def check_params *required
     true
 end
 
-def check_params_or_halt *required
-    return if check_parameters *required
-    halt 500, H.h1{"500"}+H.p{"Missing parameters"}
-end
-
 def check_api_secret
     return false if !$user
     params["apisecret"] and (params["apisecret"] == $user["apisecret"])


### PR DESCRIPTION
I noticed a couple of nested/duplicate 'form' tags. Based on looking at the login form and the css, I'm assuming the outer 'form' is supposed to be a 'div'. Hopefully that is what you intended.
Regards,
 Mark.
