### PR TITLE
Charset change and content=nofollow

### DIFF
--- a/page.rb
+++ b/page.rb
@@ -125,8 +125,9 @@ class HTMLGen
         "<!DOCTYPE html>"+
         self.html {
             H.head {
+                self.meta(:charset => "utf-8")+
                 self.title{H.entities @title}+
-                self.meta(:charset => :utf8)+
+                self.meta(:content => :nofollow, :name => :robots)+
                 self.link(:href => "/css/style.css?v=5", :rel => "stylesheet",
                           :type => "text/css")+
                 self.link(:href => "/images/favicon.png", :rel => "shortcut icon")+


### PR DESCRIPTION
- Corrected charset and moved above title because of XSS vuln in really old IE http://html5boilerplate.com/docs/The-markup/#the-order-of-charset-meta-tags-and-title
- Added content=nofollow so that google ignore links, hopefully making lamernews slightly less appealing to spammers http://www.google.com/support/webmasters/bin/answer.py?answer=96569
