### PR TITLE
Deleted news rendering should be more like deleted comment rendering.

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -250,7 +250,7 @@ get "/news/:news_id" do
     news = get_news_by_id(params["news_id"])
     halt(404,"404 - This news does not exist.") if !news
     # Show the news text if it is a news without URL.
-    if !news_domain(news)
+    if !news_domain(news) and !news["del"]
         c = {
             "body" => news_text(news),
             "ctime" => news["ctime"],
@@ -268,7 +268,7 @@ get "/news/:news_id" do
         H.section(:id => "newslist") {
             news_to_html(news)
         }+top_comment+
-        if $user
+        if $user and !news["del"]
             H.form(:name=>"f") {
                 H.inputhidden(:name => "news_id", :value => news["id"])+
                 H.inputhidden(:name => "comment_id", :value => -1)+


### PR DESCRIPTION
Currently permalink pages show the author and allow comments on deleted news. This change fixes the rendering so that it is similar to that of deleted comments - that is hiding author and comment form.

Probably the post comment api method should be fixed to prevent posting of comments with deleted (news or comment) parents.

Regards,
 Mark.
