### PR TITLE
Add a page that lists the news posted by a user.

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -137,6 +137,31 @@ get '/saved/:start' do
     }
 end
 
+get '/usernews/:username/:start' do
+    start = params[:start].to_i
+    user = get_user_by_username(params[:username])
+    halt(404,"Non existing user") if !user
+
+    page_title = "News posted by #{H.entities user['username']}"
+
+    H.set_title "#{page_title} - #{SiteName}"
+    paginate = {
+        :get => Proc.new {|start,count|
+            get_posted_news(user['id'],start,count)
+        },
+        :render => Proc.new {|item| news_to_html(item)},
+        :start => start,
+        :perpage => SavedNewsPerPage,
+        :link => "/usernews/#{H.urlencode user['username']}/$"
+    }
+    H.page {
+        H.h2 {page_title}+
+        H.section(:id => "newslist") {
+            list_items(paginate)
+        }
+    }
+end
+
 get '/usercomments/:username/:start' do
     start = params[:start].to_i
     user = get_user_by_username(params[:username])
@@ -450,6 +475,12 @@ get "/user/:username" do
                     H.a(:href=>"/usercomments/"+H.urlencode(user['username'])+
                                "/0") {
                         "user comments"
+                    }
+                }+
+                H.li {
+                    H.a(:href=>"/usernews/"+H.urlencode(user['username'])+
+                               "/0") {
+                        "user news"
                     }
                 }
             }
@@ -1512,6 +1543,13 @@ end
 def get_saved_news(user_id,start,count)
     numitems = $r.zcard("user.saved:#{user_id}").to_i
     news_ids = $r.zrevrange("user.saved:#{user_id}",start,start+(count-1))
+    return get_news_by_id(news_ids),numitems
+end
+
+# Get news posted by the specified user
+def get_posted_news(user_id,start,count)
+    numitems = $r.zcard("user.posted:#{user_id}").to_i
+    news_ids = $r.zrevrange("user.posted:#{user_id}",start,start+(count-1))
     return get_news_by_id(news_ids),numitems
 end
 


### PR DESCRIPTION
I noticed that someone [asked for this](http://lamernews.com/comment/334/12) on LN so I implemented it since it was quite trivial after all.

Actually, in the user profile, I'd move the links to the user comments and user news pages directly in the labels of the posted news and posted comments counters, leaving only the link for the saved news when the user is logged in. Let me know if you are interested in this change, I can push a new commit on this pull request.
