### PR TITLE
Fixes singularization

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -1744,7 +1744,7 @@ def str_elapsed(t)
 end
 
 def time_lengths
-    [[86400, "day"], [3600, "hour"], [60, "minute"], [1, "second"]]
+    [[604800, "week"], [86400, "day"], [3600, "hour"], [60, "minute"], [1, "second"]]
 end
 
 # Generic API limiting function


### PR DESCRIPTION
This makes "1 minute ago" and "2 minutes ago" show up correctly
also adds "week(s) ago" to the list 

\o/
