### PR TITLE
Broken titles

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -109,7 +109,7 @@ get '/latest/:start' do
         :link => "/latest/$"
     }
     H.page {
-        H.h2 {"Latest news"}
+        H.h2 {"Latest news"}+
         H.section(:id => "newslist") {
             list_items(paginate)
         }


### PR DESCRIPTION
/latest/0 has no h2 title because of a missing '+'.
Change "Top News" to "Top news" to match capitalization used elsewhere.
-Mark.
