### PR TITLE
Avoid redundant user lookup but refactoring update_auth_token api.

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -241,7 +241,7 @@ end
 
 get '/logout' do
     if $user and check_api_secret
-        update_auth_token($user["id"])
+        update_auth_token($user)
     end
     redirect "/"
 end
@@ -487,7 +487,7 @@ end
 post '/api/logout' do
     content_type 'application/json'
     if $user and check_api_secret
-        update_auth_token($user["id"])
+        update_auth_token($user)
         return {:status => "ok"}.to_json
     else
         return {
@@ -976,13 +976,11 @@ end
 #
 # Return value: on success the new token is returned. Otherwise nil.
 # Side effect: the auth token is modified.
-def update_auth_token(user_id)
-    user = get_user_by_id(user_id)
-    return nil if !user
+def update_auth_token(user)
     $r.del("auth:#{user['auth']}")
     new_auth_token = get_rand
-    $r.hmset("user:#{user_id}","auth",new_auth_token)
-    $r.set("auth:#{new_auth_token}",user_id)
+    $r.hmset("user:#{user['id']}","auth",new_auth_token)
+    $r.set("auth:#{new_auth_token}",user['id'])
     return new_auth_token
 end
 


### PR DESCRIPTION
Both calls to update_auth_token had argument '$user["id"]' and the
first thing update_auth_token does is looks up the user record.
Change update_auth_token api to take the user record instead.
