### PR TITLE
use URL for setup

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -42,8 +42,9 @@ require 'openssl' if UseOpenSSL
 
 Version = "0.11.0"
 
-def setup_redis
-    $r = Redis.new(:host => RedisHost, :port => RedisPort) if !$r
+def setup_redis(uri=RedisURL)
+    uri = URI.parse(uri)
+    $r = Redis.new(:host => uri.host, :port => uri.port, :password => uri.password) unless $r
 end
 
 before do

--- a/app_config.rb
+++ b/app_config.rb
@@ -4,8 +4,7 @@ SiteUrl = "http://lamernews.com"
 SiteDescription = "Programming News"
 
 # Redis config
-RedisHost = "127.0.0.1"
-RedisPort = 10000
+RedisURL = "redis://127.0.0.1:10000"
 
 # Security
 PBKDF2Iterations = 1000 # Set this to 5000 to improve security. But it is slow.


### PR DESCRIPTION
In order to make the setup of the Lamernews easier with RedisToGo, it would be nice to pass in an URL for the Redis setup, like:

```
redis://redistogo:44ec0bc04dd4a5afe77a649acee7a8f3@drum.redistogo.com:9092/
```

The host, port _and_ password can be extracted from the URL above, and also, RedisHost and RedisPort can be removed from the config.
