### PR TITLE
Fix for upstream issue #145: "Ruby 2.0 problem coming from pbkdf2"

### DIFF
--- a/pbkdf2.rb
+++ b/pbkdf2.rb
@@ -140,7 +140,7 @@ end
 class String
   if RUBY_VERSION >= "1.9"
     def xor_impl(other)
-      result = ""
+      result = "".encode("ASCII-8BIT")
       o_bytes = other.bytes.to_a
       bytes.each_with_index do |c, i|
         result << (c ^ o_bytes[i])


### PR DESCRIPTION
This implements the fix for #145 that github user @killwhitey suggested [here](https://github.com/antirez/lamernews/issues/145#issuecomment-60553778)